### PR TITLE
chore: update runner to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "The file path to ast-grep's project config relative to root dir"
     default: ''
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'zap'


### PR DESCRIPTION
Update GitHub Actions to versions using supported versions of NodeJS, same as the internal GitHub Actions.
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ as well as the updated template https://github.com/actions/javascript-action/blob/main/action.yml#L18C10-L18C16