### PR TITLE
Add support for running the action on limited paths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ast-grep lint step
-        id: hello
+        id: basic
         uses: ./ # Uses an action in the root directory
-      # Use the output from the `hello` step
+      # Use the output from the `basic` step
       - name: Get the output time
-        run: echo "The time was ${{ steps.hello.outputs.exitCode }}"
+        run: echo "The time was ${{ steps.basic.outputs.exitCode }}"
+      - name: ast-grep lint step
+        id: advanced
+        uses: ./ # Uses an action in the root directory
+        with:
+          config: sgconfig.yml
+          paths: src
+      # Use the output from the `advanced` step
+      - name: Get the output time
+        run: echo "The time was ${{ steps.advanced.outputs.exitCode }}"

--- a/README.md
+++ b/README.md
@@ -51,4 +51,5 @@ jobs:
         with:
           version: 0.17.1
           config: sgconfig.yml
+          paths: src lib
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,24 @@ async function main() {
   } else {
     await exec.exec('npm', ['install', '@ast-grep/cli', '--global'])
   }
+
   const config = core.getInput('config')
-  const args = config
-    ? ['scan', '-c', config, '--format', 'github']
-    : ['scan', '--format', 'github']
+  const paths = core.getInput('paths')
+  const args = ['scan']
+
+  if (config) {
+    args.push('-c', config)
+  }
+
+  args.push('--format', 'github')
+
+  if (paths) {
+    // GitHub actions doesn't support a YAML list, so use a string
+    // https://stackoverflow.com/questions/75420197/how-to-use-array-input-for-a-custom-github-actions
+    // and allow for escaped whitespace
+    args.push(...paths.split(/(?<!\\)\s+/))
+  }
+
   await exec.exec('ast-grep', args)
 }
 


### PR DESCRIPTION
This adds an additional input, `paths`, corresponding to `PATHS` passed to the ast-grep cli, to limit the paths the action runs on.

Test Plan: Extended the workflow to include an advanced testcase.
