### PR TITLE
chore: update runner to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   paths:
     description: "Whitespace-delimited paths to lint"
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'zap'


### PR DESCRIPTION
GitHub is deprecating the Node.js 20 action runtime (forced to node24 on 2026-06-16, removed 2026-09-16). Bumps `runs.using` from node20 to node24 — the successor to #15. dist is unchanged.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/